### PR TITLE
Adding Box Mapping Function

### DIFF
--- a/Csg.PerfTest/Csg.PerfTest.csproj
+++ b/Csg.PerfTest/Csg.PerfTest.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net70</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Csg.Test/Csg.Test.csproj
+++ b/Csg.Test/Csg.Test.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net70</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Csg/Solid.cs
+++ b/Csg/Solid.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace Csg

--- a/Csg/Solid.cs
+++ b/Csg/Solid.cs
@@ -310,7 +310,7 @@ namespace Csg
 			}
 		}
 
-		BoundingBox Bounds {
+		public BoundingBox Bounds {
 			get {
 				if (cachedBoundingBox == null) {
 					var minpoint = new Vector3D (0, 0, 0);

--- a/Runner.CPurlin/Runner.CPurlin.csproj
+++ b/Runner.CPurlin/Runner.CPurlin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Runner.Examples/Runner.Examples.csproj
+++ b/Runner.Examples/Runner.Examples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
the library does have the uv property on vertexes, but doesnt use it anywhere, so every resulting solid will always have uvs 0,0. i added a box mapping function to generate simple uvs. i also made Bounds public so its easier to add such mappings from outside the library (my attempt in my own code used reflection to get that property).

also bumped version from net7 to net8 for the other projects, as net7 is already EOL and net8 is an LTS release (which doesnt mean that much, but eh)